### PR TITLE
Ch6: Bulk delete uses params under htmx 2.0

### DIFF
--- a/ch06-more-htmx-patterns.typ
+++ b/ch06-more-htmx-patterns.typ
@@ -1301,7 +1301,7 @@ looks like:
 def contacts_delete_all():
     contact_ids =  [
       int(id)
-      for id in request.form.getlist("selected_contact_ids")
+      for id in request.args.getlist("selected_contact_ids")
     ] <2>
     for contact_id in contact_ids: <3>
         contact = Contact.find(contact_id)


### PR DESCRIPTION
This change accounts for the switch from a form body to URL parameters for HTTP DELETE in htmx 2.0, in the bulk-delete contacts example.

Only the attribute on the request object needs to change for this to work (`args` instead of `form`).