### PR TITLE
Fix issue #5: Copy images folder to _site

### DIFF
--- a/www/build_web.ts
+++ b/www/build_web.ts
@@ -108,4 +108,5 @@ console.log(built.length);
 write(built, { directory: "_site" })
 copySync("www/style.css", "_site/style.css");
 copySync("fonts", "_site/fonts");
+copySync("images", "_site/images");
 copySync("www/color-customizer.js", "_site/color-customizer.js");


### PR DESCRIPTION
This PR fixes issue #5 by ensuring the images folder is copied to the _site directory, resolving the issue of missing images on the new website version.