### PR TITLE
Reference numbering issues on Client Side Scripting chapter

### DIFF
--- a/asciidoc/CH09_ScriptingInAHypermediaApplication.adoc
+++ b/asciidoc/CH09_ScriptingInAHypermediaApplication.adoc
@@ -544,7 +544,7 @@ function overflowMenu(subtree = document) {
   subtree.querySelectorAll("[data-overflow-menu]").forEach(menuRoot => { <1>
     const
     button = menuRoot.querySelector("[aria-haspopup]"), <2>
-    menu = menuRoot.querySelector("[role=menu]"), <2>
+    menu = menuRoot.querySelector("[role=menu]"),
     items = [...menu.querySelectorAll("[role=menuitem]")]; <3>
   });
 }

--- a/ch09-client-side-scripting.typ
+++ b/ch09-client-side-scripting.typ
@@ -513,7 +513,7 @@ Here is what our code looks like now:
 #figure[
 ```js
 // counter.js <1>
-document.querySelectorAll("[data-counter]") <1>
+document.querySelectorAll("[data-counter]") <2>
   .forEach(el => {
     const
     output = el.querySelector("[data-counter-output]"),

--- a/ch09-client-side-scripting.typ
+++ b/ch09-client-side-scripting.typ
@@ -658,8 +658,8 @@ function overflowMenu(tree = document) {
   tree.querySelectorAll("[data-overflow-menu]").forEach(menuRoot => { <1>
     const
     button = menuRoot.querySelector("[aria-haspopup]"), <2>
-    menu = menuRoot.querySelector("[role=menu]"), <3>
-    items = [...menu.querySelectorAll("[role=menuitem]")];
+    menu = menuRoot.querySelector("[role=menu]"),
+    items = [...menu.querySelectorAll("[role=menuitem]")]; <3>
   });
 }
 


### PR DESCRIPTION
These commits fix a few issues with the numbering of code samples within the Client Side Scripting chapter; specifically, duplicate, missing, or mis-placed references.