### PR TITLE
Add `position: absolute` to `.vh`

### DIFF
--- a/ch05-htmx-patterns.typ
+++ b/ch05-htmx-patterns.typ
@@ -1266,6 +1266,7 @@ through styling), you can use this utility class:
 #figure(
 ```css
 .vh {
+    position: absolute;
     clip: rect(0 0 0 0);
     clip-path: inset(50%);
     block-size: 1px;


### PR DESCRIPTION
It seems that the `.vh` class, which is used to visually hide content while still being accessible to assistive technologies, also requires a `position: absolute` style declaration.

If it is not positioned absolutely, the 1px square box will continue to remain, and the style will be unintentionally broken.

Scott O'Hara's “Inclusively Hidden” also includes `position: absolute`.
https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html

I've prepared an example to show the contrast.
https://codepen.io/tsmd/pen/VwJBrGa?editors=1100