### PR TITLE
Mostly typo fixes and standardization of Chapter # format.

### DIFF
--- a/asciidoc/CH06_MorehtmxPatterns.adoc
+++ b/asciidoc/CH06_MorehtmxPatterns.adoc
@@ -60,7 +60,7 @@ So, in addition to the regular form behavior, we _also_ want to issue an HTTP `G
 to issue this request to the same URL as the normal form submission.  Finally, we only want to do this after a small
 pause in typing has occurred.
 
-As we said, this functionality is very similar to what we needed for email validation. We can, in fact copy
+As we said, this functionality is very similar to what we needed for email validation. In fact, we can copy
 the `hx-trigger` attribute directly from our email validation example, with its small 200-millisecond delay, to allow a
 user to stop typing before a request is triggered.
 

--- a/asciidoc/CH06_MorehtmxPatterns.adoc
+++ b/asciidoc/CH06_MorehtmxPatterns.adoc
@@ -1174,7 +1174,7 @@ the web.
 (((accessibility)))
 Accessibility problems can arise when we try to implement controls that aren't built into HTML.
 
-Earlier, in Chapter One, we looked at the example of a <div> improvised to work like a button.
+Earlier, in Chapter 1, we looked at the example of a <div> improvised to work like a button.
 Let's look at a different example: what if you make something that looks like a set of tabs, but you use radio buttons and CSS hacks to build it? It's a neat hack that makes the rounds in web development communities from time to time.
 
 The problem here is that tabs have requirements beyond clicking to change content.

--- a/asciidoc/CH06_MorehtmxPatterns.adoc
+++ b/asciidoc/CH06_MorehtmxPatterns.adoc
@@ -726,7 +726,7 @@ we are just doing it in a second request.  You aren't really waiting until the v
 
 Fine.  Let's make it _lazy_ lazy: we'll only issue the request when the `span` scrolls into view.
 
-To do that, lets recall how we set up the infinite scroll example: we used the `revealed` event for our trigger.  That's
+To do that, let's recall how we set up the infinite scroll example: we used the `revealed` event for our trigger.  That's
 all we want here, right?  When the element is revealed we issue the request?
 
 Yep, that's it.  Once again, we can mix and match concepts across various UX patterns to come up with solutions to

--- a/asciidoc/CH06_MorehtmxPatterns.adoc
+++ b/asciidoc/CH06_MorehtmxPatterns.adoc
@@ -61,7 +61,7 @@ to issue this request to the same URL as the normal form submission.  Finally, w
 pause in typing has occurred.
 
 As we said, this functionality is very similar to what we needed for email validation. In fact, we can copy
-the `hx-trigger` attribute directly from our email validation example, with its small 200-millisecond delay, to allow a
+the `hx-trigger` attribute directly from our email validation example, with its small 200-millisecond delay, to wait for a
 user to stop typing before a request is triggered.
 
 This is another example of how common patterns come up again and again when using htmx.

--- a/asciidoc/CH07_ADynamicArchiveUIWithhtmx.adoc
+++ b/asciidoc/CH07_ADynamicArchiveUIWithhtmx.adoc
@@ -672,7 +672,7 @@ file. Another pattern that we see on the web is "auto-downloading", where the fi
 needing to click a link.
 
 We can add this functionality quite easily to our application with just a bit of scripting.  We will discuss scripting
-in a Hypermedia-Driven Application in more depth in chapter 9, but, put briefly: scripting is perfectly
+in a Hypermedia-Driven Application in more depth in Chapter 9, but, put briefly: scripting is perfectly
 acceptable in a HDA, as long as it doesn't replace the core hypermedia mechanics of the application.
 
 For our auto-download feature we will use https://hyperscript.org[+_hyperscript+], our preferred scripting option.

--- a/asciidoc/CH08_TricksOfThehtmxMasters.adoc
+++ b/asciidoc/CH08_TricksOfThehtmxMasters.adoc
@@ -49,7 +49,7 @@ Hypermedia-Driven Applications.
 === hx-swap
 
 (((hx-swap)))
-We'll start with the hx-swap attribute. This is often not included on elements that issue htmx-driven requests because
+We'll start with the `hx-swap` attribute. This is often not included on elements that issue htmx-driven requests because
 its default behavior -- `innerHTML`, which swaps the inner HTML of the element -- tends to cover most use cases.
 
 We earlier saw situations where we wanted to override the default behavior and use `outerHTML`, for example.  And, in

--- a/asciidoc/CH08_TricksOfThehtmxMasters.adoc
+++ b/asciidoc/CH08_TricksOfThehtmxMasters.adoc
@@ -53,9 +53,9 @@ We'll start with the hx-swap attribute. This is often not included on elements t
 its default behavior -- `innerHTML`, which swaps the inner HTML of the element -- tends to cover most use cases.
 
 We earlier saw situations where we wanted to override the default behavior and use `outerHTML`, for example.  And, in
-chapter 2, we discussed some other swap options beyond these two, `beforebegin`, `afterend`, etc.
+Chapter 2, we discussed some other swap options beyond these two, `beforebegin`, `afterend`, etc.
 
-In chapter 5, we also looked at the `swap` delay modifier for `hx-swap`, which allowed us to fade some content out
+In Chapter 5, we also looked at the `swap` delay modifier for `hx-swap`, which allowed us to fade some content out
 before it was removed from the DOM.
 
 In addition to these, `hx-swap` offers further control with the following modifiers:
@@ -533,7 +533,7 @@ general mechanism for refreshing the contacts table in our application.
 == HTTP Requests & Responses
 
 We have just seen an advanced feature of HTTP responses supported by htmx, the `HX-Trigger` response header,
-but htmx supports quite a few more headers for both requests and responses.  In chapter 4 we discussed the
+but htmx supports quite a few more headers for both requests and responses.  In Chapter 4 we discussed the
 headers present in HTTP Requests.  Here are some of the more important headers you can use to change htmx behavior with
 HTTP responses:
 

--- a/asciidoc/CH11_HyperviewAMobileHypermedia.adoc
+++ b/asciidoc/CH11_HyperviewAMobileHypermedia.adoc
@@ -326,7 +326,7 @@ Some mobile OSes will use a different transition for the header than the rest of
 (((HXML, "<view>")))
 `<view>` is the basic building block for layouts and structure within the screen's body.
 Think of it like a `<div>` in HTML.
-Note that unlike in HTML, a `<div>` cannot directly contain text.
+Note that unlike in HTML, a `<view>` cannot directly contain text.
 
 (((HXML, "<text>")))
 `<text>` elements are the only way to render text in the UI.

--- a/asciidoc/CH12_BuildingAContactsAppWithHyperview.adoc
+++ b/asciidoc/CH12_BuildingAContactsAppWithHyperview.adoc
@@ -196,7 +196,7 @@ It also allows the server to respond with just the `rows.xml` template for inter
 In the web app, each row in the list showed the contact's name, phone number, and email address.
 But in a mobile app, we have less real-estate.
 It would be hard to cram all this information into one line.
-Instead, the row just shows the contact's first and last name, and falls back to email or phone if the name is not set.
+Instead, the row just shows the contact's first and last name, and falls back to phone or email if the name is not set.
 To render the row, we again make use of Jinja template syntax to render dynamic text with data passed to the template.
 
 We now have templates for the base layout, the contacts screen, and the contact rows.

--- a/asciidoc/CH12_BuildingAContactsAppWithHyperview.adoc
+++ b/asciidoc/CH12_BuildingAContactsAppWithHyperview.adoc
@@ -1201,7 +1201,7 @@ def render_to_response(template_name, *args, **kwargs):
     return response
 ----
 
-`render_to_response()` renders a template with the given context, and turns it into an Flask response object with the appropriate Hyperview `Content-Type` header.
+`render_to_response()` renders a template with the given context, and turns it into a Flask response object with the appropriate Hyperview `Content-Type` header.
 Obviously, the implementation is highly-specific to serving our Hyperview mobile app.
 But we can modify the function to do content negotiation based on the request's `Accept` header:
 

--- a/ch04-extending-html-as-hypermedia.typ
+++ b/ch04-extending-html-as-hypermedia.typ
@@ -87,11 +87,10 @@ and address the issues with legacy HTML applications we mentioned above (as well
 as a few others.)
 
 Before we get into how htmx allows us to improve the UX of our Web 1.0 style
-application, let’s revisit the hyperlink/anchor tag from Chapter
-1. Recall, a hyperlink is what is known as a _hypermedia control_,
-a mechanism that describes some sort of interaction with a server by encoding
-information about that interaction directly and completely within the control
-itself.
+application, let’s revisit the hyperlink/anchor tag from Chapter 1. Recall, a
+hyperlink is what is known as a _hypermedia control_, a mechanism that describes
+some sort of interaction with a server by encoding information about that
+interaction directly and completely within the control itself.
 
 Consider again this simple #indexed[anchor tag] which, when interpreted by a
 browser, creates a #indexed[hyperlink] to the website for this book:

--- a/ch04-extending-html-as-hypermedia.typ
+++ b/ch04-extending-html-as-hypermedia.typ
@@ -804,7 +804,7 @@ Let’s take our original #indexed[search] form and convert it to use htmx inste
 </form>
 ```)
 
-1. When an htmx-powered element is withing an ancestor form tag, all input values within that
+1. When an htmx-powered element is within an ancestor form tag, all input values within that
    form will be submitted for non-`GET` requests
 2. We have switched from an `input` of type `submit` to a `button` and added the `hx-post` attribute
 

--- a/ch06-more-htmx-patterns.typ
+++ b/ch06-more-htmx-patterns.typ
@@ -69,7 +69,7 @@ typing has occurred.
 
 As we said, this functionality is very similar to what we needed for email
 validation. In fact, we can copy the `hx-trigger` attribute directly from our
-email validation example, with its small 200-millisecond delay, to allow a user
+email validation example, with its small 200-millisecond delay, to wait for a user
 to stop typing before a request is triggered.
 
 This is another example of how common patterns come up again and again when

--- a/ch06-more-htmx-patterns.typ
+++ b/ch06-more-htmx-patterns.typ
@@ -68,7 +68,7 @@ normal form submission. Finally, we only want to do this after a small pause in
 typing has occurred.
 
 As we said, this functionality is very similar to what we needed for email
-validation. We can, in fact copy the `hx-trigger` attribute directly from our
+validation. In fact, we can copy the `hx-trigger` attribute directly from our
 email validation example, with its small 200-millisecond delay, to allow a user
 to stop typing before a request is triggered.
 

--- a/ch06-more-htmx-patterns.typ
+++ b/ch06-more-htmx-patterns.typ
@@ -1338,7 +1338,7 @@ manner of the web.
 Accessibility problems can arise when we try to implement controls that aren’t
 built into HTML.
 
-Earlier, in Chapter One, we looked at the example of a \<div\> improvised to
+Earlier, in Chapter 1, we looked at the example of a \<div\> improvised to
 work like a button. Let’s look at a different example: what if you make
 something that looks like a set of tabs, but you use radio buttons and CSS hacks
 to build it? It’s a neat hack that makes the rounds in web development

--- a/ch06-more-htmx-patterns.typ
+++ b/ch06-more-htmx-patterns.typ
@@ -838,7 +838,7 @@ You aren’t really waiting until the value is actually needed."
 Fine. Let’s make it _lazy_ lazy: we’ll only issue the request when the `span` scrolls
 into view.
 
-To do that, lets recall how we set up the infinite scroll example: we used the `revealed` event
+To do that, let's recall how we set up the infinite scroll example: we used the `revealed` event
 for our trigger. That’s all we want here, right? When the element is revealed we
 issue the request?
 

--- a/ch06-more-htmx-patterns.typ
+++ b/ch06-more-htmx-patterns.typ
@@ -838,7 +838,7 @@ You aren’t really waiting until the value is actually needed."
 Fine. Let’s make it _lazy_ lazy: we’ll only issue the request when the `span` scrolls
 into view.
 
-To do that, let's recall how we set up the infinite scroll example: we used the `revealed` event
+To do that, let’s recall how we set up the infinite scroll example: we used the `revealed` event
 for our trigger. That’s all we want here, right? When the element is revealed we
 issue the request?
 

--- a/ch07-a-dynamic-archive-ui.typ
+++ b/ch07-a-dynamic-archive-ui.typ
@@ -740,7 +740,7 @@ the file downloads immediately without the user needing to click a link.
 
 We can add this functionality quite easily to our application with just a bit of
 scripting. We will discuss scripting in a Hypermedia-Driven Application in more
-depth in chapter 9, but, put briefly: scripting is perfectly acceptable in a
+depth in Chapter 9, but, put briefly: scripting is perfectly acceptable in a
 HDA, as long as it doesn’t replace the core hypermedia mechanics of the
 application.
 

--- a/ch08-tricks-of-the-htmx-masters.typ
+++ b/ch08-tricks-of-the-htmx-masters.typ
@@ -51,7 +51,7 @@ options for creating more advanced Hypermedia-Driven Applications.
 
 ==== #indexed[hx-swap]
 
-We’ll start with the hx-swap attribute. This is often not included on elements
+We’ll start with the `hx-swap` attribute. This is often not included on elements
 that issue htmx-driven requests because its default behavior --- `innerHTML`,
 which swaps the inner HTML of the element --- tends to cover most use cases.
 

--- a/ch08-tricks-of-the-htmx-masters.typ
+++ b/ch08-tricks-of-the-htmx-masters.typ
@@ -56,11 +56,11 @@ that issue htmx-driven requests because its default behavior --- `innerHTML`,
 which swaps the inner HTML of the element --- tends to cover most use cases.
 
 We earlier saw situations where we wanted to override the default behavior and
-use `outerHTML`, for example. And, in chapter 2, we discussed some other swap
+use `outerHTML`, for example. And, in Chapter 2, we discussed some other swap
 options beyond these two, `beforebegin`,
 `afterend`, etc.
 
-In chapter 5, we also looked at the `swap` delay modifier for `hx-swap`, which
+In Chapter 5, we also looked at the `swap` delay modifier for `hx-swap`, which
 allowed us to fade some content out before it was removed from the DOM.
 
 In addition to these, `hx-swap` offers further control with the following
@@ -624,7 +624,7 @@ refreshing the contacts table in our application.
 === HTTP Requests & Responses <_http_requests_responses>
 We have just seen an advanced feature of HTTP responses supported by htmx, the `HX-Trigger` response
 header, but htmx supports quite a few more headers for both requests and
-responses. In chapter 4 we discussed the headers present in HTTP Requests. Here
+responses. In Chapter 4 we discussed the headers present in HTTP Requests. Here
 are some of the more important headers you can use to change htmx behavior with
 HTTP responses:
 

--- a/ch09-client-side-scripting.typ
+++ b/ch09-client-side-scripting.typ
@@ -514,7 +514,7 @@ Here is what our code looks like now:
 #figure[
 ```js
 // counter.js <1>
-document.querySelectorAll("[data-counter]") <1>
+document.querySelectorAll("[data-counter]") <2>
   .forEach(el => {
     const
     output = el.querySelector("[data-counter-output]"),

--- a/ch11-hyperview-a-mobile-hypermedia.typ
+++ b/ch11-hyperview-a-mobile-hypermedia.typ
@@ -1216,7 +1216,7 @@ child elements to represent the behavior of each button.
   action="alert" <2>
   alert:title="Continue to next screen?" <3>
   alert:message=
-    "Are you sure you want to navigateto the next screen?" <4>
+    "Are you sure you want to navigate to the next screen?" <4>
 >
   <alert:option alert:label="Continue"> <5>
     <behavior action="push" href="/next" /> <6>

--- a/ch12-building-a-contacts-app-with-hyperview.typ
+++ b/ch12-building-a-contacts-app-with-hyperview.typ
@@ -1396,7 +1396,7 @@ def render_to_response(template_name, *args, **kwargs):
 ``` ]
 
 `render_to_response()` renders a template with the given context, and turns it
-into an Flask response object with the appropriate Hyperview
+into a Flask response object with the appropriate Hyperview
 `Content-Type` header. Obviously, the implementation is highly-specific to
 serving our Hyperview mobile app. But we can modify the function to do content
 negotiation based on the request’s `Accept` header:

--- a/ch12-building-a-contacts-app-with-hyperview.typ
+++ b/ch12-building-a-contacts-app-with-hyperview.typ
@@ -214,7 +214,7 @@ infinite scroll, and pull-to-refresh.
 In the web app, each row in the list showed the contact’s name, phone number,
 and email address. But in a mobile app, we have less real-estate. It would be
 hard to cram all this information into one line. Instead, the row just shows the
-contact’s first and last name, and falls back to email or phone if the name is
+contact’s first and last name, and falls back to phone or email if the name is
 not set. To render the row, we again make use of Jinja template syntax to render
 dynamic text with data passed to the template.
 

--- a/ch13-extending-the-hyperview-client.typ
+++ b/ch13-extending-the-hyperview-client.typ
@@ -826,7 +826,7 @@ it exactly using hypermedia. While htmx and Hyperview significantly improve the
 user experience available via the hypermedia-driven approach, there are still
 times when it won’t be easy to pull of a particular user experience.
 
-As we saw in Chapter Two, Roy Fielding noted this tradeoff with respect to the
+As we saw in Chapter 2, Roy Fielding noted this tradeoff with respect to the
 web’s RESTful network architecture, where "information is transferred in a
 standardized form rather than one which is specific to an application’s needs."
 


### PR DESCRIPTION
Many thanks for this wonderful book! I wanted to show my appreciation with a simple pr with mostly typo fixes. Each commit is pretty atomic just fixing one thing and the commit message says what the change is. The only systematic change is that the different ways chapters are referenced (Chapter 3, chapter 3, Chapter Three) are normalized to Chapter 3.

There are some other things I noticed that I didn't change in this pr, either because I don't know how to or because it's more debatable. I'll share those things here for your consideration:

1. In Chapter 6, your backend code has a list comprehension followed by a regular for loop. The for loop syntax inside of a list comprehension is kind of backwards with respect to regular for-loop syntax, so it would be better to combine these two loops into one. That would simplify the syntax for readers that are not familiar with python. This is what the result would be:
```
@app.route("/contacts/", methods=["DELETE"]) <1>
def contacts_delete_all():
    for contact_id in request.form.getlist("selected_contact_ids"): <3>
        contact_id_int = int(contact_id) <2>
        contact = Contact.find(contact_id_int)
        contact.delete() <4>
    flash("Deleted Contacts!") <5>
    contacts_set = Contact.all()
    return render_template("index.html", contacts=contacts_set)
```
This would also require revisiting the <2> and <3> references in the passage above, as well as the reference to "16 lines of backend code" in Chapter 7. Oh and I noticed that your contact-app repo similarly has two loops but that one uses `list(map(...`. That's not better than a single for loop either.
2. The urls in the attribution parameters of blockquotes don't parse as links which seems inconsistent for a hypermedia book. E.g. the Ted Nelson quote in Chapter 1.
3. It would be really slick if the footnotes (like those in Chapter 9) displayed the text of the footnote in the way most html elements do with the "title" text. I couldn't tell how to make that work in your setup though.
4. Not a big deal, but the "Apply" button in your "Customize Colors" panel doesn't do anything. Colors get applied as soon as they're selected and pushing the Apply button doesn't even close the panel.
5. Also regarding the color panel, maybe there should be a color picker for the HTML Notes panel background as well. Because if you invert the colors with white text on a black background, the background of those panels doesn't change and white on pale blue is really hard to read.
6. In Chapter 12, the screenshot referred to here seems to have been taken later in the development process. At this point in the book, I don't think we should have the "Edit" button yet. See: #figure([#image("images/screenshot_hyperview_detail_cropped.png")]
7. Also in Chapter 12 you say "the Hyperview client only understands `GET` and `POST`." No mistake per se, but I can't believe it. Did you really limit Hyperview to only GET and POST requests? Why would that be the case?