### PR TITLE
Clarify that divs are not part of HXML

### DIFF
--- a/ch11-hyperview-a-mobile-hypermedia.typ
+++ b/ch11-hyperview-a-mobile-hypermedia.typ
@@ -360,7 +360,7 @@ the screen content.
 
 #index[HXML][\<view\>]
 `<view>` is the basic building block for layouts and structure within the
-screen’s body. Think of it like a `<div>` in HTML. Note that unlike in HTML, a `<div>` cannot
+screen’s body. Think of it like a `<div>` in HTML. Note that unlike HTML `<div>` elements, a `<view>` cannot
 directly contain text.
 
 #index[HXML][\<text\>]


### PR DESCRIPTION
Hello, thanks for your amazing work on pushing Hypermedia systems forward! Just offering a small clarification to the introduction to HXML `<view>` elements, as the sentence slightly confused me when I first read it.

The sentence previously read as though `<div>` was part of the HXML spec, but that in HXML it couldn't contain text directly. I believe the intention was to say that the `HXML`  `<view>` element can't contain text directly, unlike HTML `<div>` elements?