### PR TITLE
Replaced git@github.com with public https://github.com in Ch12

### DIFF
--- a/ch12-building-a-contacts-app-with-hyperview.typ
+++ b/ch12-building-a-contacts-app-with-hyperview.typ
@@ -58,7 +58,7 @@ using Expo. We will use this demo client but point it to our contacts app
 backend as a starting point.
 
 #figure[```bash
-git clone git@github.com:Instawork/hyperview.git
+git clone https://github.com/Instawork/hyperview.git
 cd hyperview/demo
 yarn <1>
 yarn start <2>


### PR DESCRIPTION
I recommend replacing git@github.com with public https://github.com in the hyperview documentation. If you replace the SSH link with a HTTPS link, the command works for users that do not have SSH keys configured in their system.

```
PS F:\tests> git clone git@github.com:Instawork/hyperview.git
Cloning into 'hyperview'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```