### PR TITLE
Obtain current position via `locate`

### DIFF
--- a/lib/indexing.typ
+++ b/lib/indexing.typ
@@ -5,7 +5,7 @@
 #let index(..content) = if is-pandoc {
   //
 } else {
-  context [#metadata((content: content.pos(), location: here()))<jkrb_index>]
+  locate(loc => [#metadata((content: content.pos(), location: loc))<jkrb_index>])
 }
 
 #let indexed(content) = [#index(content)#content]


### PR DESCRIPTION
This fixes generation of ePUB format with the latest `pandoc` / `typst` releases.

Fixes #37 