### PR TITLE
Fix table header ordering in ch03 contacts.app index template

### DIFF
--- a/code/ch03-web10/templates/index.html
+++ b/code/ch03-web10/templates/index.html
@@ -19,10 +19,10 @@
     <table>
         <thead>
         <tr>
+            <th>Email</th>
             <th>First</th>
             <th>Last</th>
             <th>Phone</th>
-            <th>Email</th>
             <th></th>
         </tr>
         </thead>


### PR DESCRIPTION
I noticed the table header ordering in the contacts app example code did not match the table field ordering. This change moves the email header to the first column to match the table data. 

Table fields: email | first | last | phone
Original headers: first | last | phone | email
New headers: email | first | last | phone

