### PR TITLE
Fix mobile full table of contents layout

### DIFF
--- a/www/muteferrika/lib/templates/table-of-contents.ts
+++ b/www/muteferrika/lib/templates/table-of-contents.ts
@@ -43,9 +43,7 @@ export default /* html */`
 {{ /function }}
 
 <main>
-  <div class="toc-content">
-    {{ self.compiledContent |> safe }}
-  </div>
+  {{ self.compiledContent |> safe }}
   {{ recurse(self.book) }}
 </main>
 

--- a/www/style.css
+++ b/www/style.css
@@ -299,6 +299,17 @@ label {
     }
   }
 
+  #show-internal-contents:checked ~ ul {
+    &, ul {
+      column-width: auto;
+      column-count: 1;
+    }
+
+    ul.internal-contents {
+      display: block;
+    }
+  }
+
   a {
     text-decoration: none;
 

--- a/www/tocheader.html
+++ b/www/tocheader.html
@@ -1,17 +1,2 @@
-<label>
-  <input type="checkbox" id="show-internal-contents"
-    onchange="
-      document.querySelectorAll('.internal-contents')
-        .forEach(el => el.style.display = this.checked ? 'block' : 'none')
-      document.querySelectorAll('ul')
-        .forEach(el => el.style.columnCount = this.checked ? 1 : 'auto')
-      
-      ">
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      document.getElementById('show-internal-contents')
-        .dispatchEvent(new Event('change'))
-    })
-  </script>
-  Show full table of contents
-</label>
+<input type="checkbox" id="show-internal-contents">
+<label for="show-internal-contents">Show full table of contents</label>


### PR DESCRIPTION
Noticed a layout bug on https://hypermedia.systems/book/contents/ from my iOS device. When checking "Show full table of contents", the content would overlap.

Fixed and replaced toggle logic from JS to CSS.

**Before:**
<img width="200" alt="Before" src="https://github.com/user-attachments/assets/a8519c06-a248-45e3-8d42-c9fe82176250" />

**After:**
<img width="200" alt="After" src="https://github.com/user-attachments/assets/f9980ae4-23ed-4aad-b4ed-7fb87813228f" />
