### PR TITLE
Fix mobile prose overflow

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -83,6 +83,10 @@ body {
   margin: 0;
 }
 
+html:not(.table-of-contents) main {
+  overflow-wrap: break-word;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--display);
   font-weight: normal;
@@ -131,6 +135,7 @@ header, footer {
 }
 
 pre {
+  overflow-wrap: normal;
   overflow-x: auto;
   margin-inline-end: calc((100% - 100vw) / 2);
   padding-block: .75em;


### PR DESCRIPTION
Noticed another layout bug on https://hypermedia.systems/hypermedia-a-reintroduction/ from my iOS device. 

A long URL would widen the page, making the content appear zoomed out/changing the viewport width.

Fixed by allowing prose content to wrap long unbroken text while preserving horizontal scrolling for code blocks.

**Before:**
<img width="200" alt="Copyright   Acknowledgments" src="https://github.com/user-attachments/assets/0d607248-e1f7-4468-b4a1-325b101e912e" />

**After:**
<img width="200" alt="Copyright   Acknowledgments 2" src="https://github.com/user-attachments/assets/9da8bd3f-08c2-47d2-b6a1-29a2921e47b0" />
