### PR TITLE
Hide empty contents sections

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -357,6 +357,10 @@ label {
 .division-toc {
   font-family: var(--secondary);
 
+  &:not(:has(ul)) {
+    display: none;
+  }
+
   summary {
     font-size: inherit;
     font-weight: bold;


### PR DESCRIPTION
Noticed an empty Contents section on https://hypermedia.systems/foreword/.

The page has no section links to show, but still renders the Contents disclosure.

Fixed by hiding empty Contents disclosures.

**Before:**
<img width="300" alt="Before" src="https://github.com/user-attachments/assets/56330797-a6c5-44cc-b295-853b33902423" />

**After:**
(note the missing "Contents")
<img width="300" alt="After" src="https://github.com/user-attachments/assets/d8ef8188-e181-4076-a992-5ba9c987f8f2" />
